### PR TITLE
Fix Vercel function runtime version specification

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3,7 +3,7 @@
   "outputDirectory": "dist/spa",
   "functions": {
     "api/index.ts": {
-      "runtime": "@vercel/node"
+      "runtime": "@vercel/node@20.x"
     }
   },
   "routes": [

--- a/vercel.json
+++ b/vercel.json
@@ -3,7 +3,7 @@
   "outputDirectory": "dist/spa",
   "functions": {
     "api/index.ts": {
-      "runtime": "@vercel/node@20.x"
+      "runtime": "@vercel/node@18.x"
     }
   },
   "routes": [


### PR DESCRIPTION
## Purpose
Fix deployment failures caused by invalid function runtime specification. Users were encountering "Build Failed: Function Runtimes must have a valid version" errors when deploying to Vercel.

## Code changes
- Updated `vercel.json` to specify explicit Node.js runtime version
- Changed `"runtime": "@vercel/node"` to `"runtime": "@vercel/node@18.x"`
- Ensures compliance with Vercel's requirement for versioned runtime specifications

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 4`

🔗 [Edit in Builder.io](https://builder.io/app/projects/90e3e6b9e05f4cf9bf312bea10483dd7/pixel-works)

👀 [Preview Link](https://90e3e6b9e05f4cf9bf312bea10483dd7-pixel-works.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>90e3e6b9e05f4cf9bf312bea10483dd7</projectId>-->
<!--<branchName>pixel-works</branchName>-->