### PR TITLE
Remove Express backend, convert to frontend-only React app

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,6 @@
     "typecheck": "tsc"
   },
   "dependencies": {
-    "dotenv": "^17.2.0",
-    "express": "^4.18.2",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -55,8 +55,7 @@
     "@swc/core": "^1.11.24",
     "@tailwindcss/typography": "^0.5.15",
     "@tanstack/react-query": "^5.56.2",
-    "@types/cors": "^2.8.17",
-    "@types/express": "^4.17.21",
+
     "@types/node": "^22.5.5",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
@@ -67,7 +66,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.0.0",
-    "cors": "^2.8.5",
+
     "date-fns": "^3.6.0",
     "embla-carousel-react": "^8.3.0",
     "framer-motion": "^12.6.2",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "@swc/core": "^1.11.24",
     "@tailwindcss/typography": "^0.5.15",
     "@tanstack/react-query": "^5.56.2",
-
     "@types/node": "^22.5.5",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
@@ -66,7 +65,6 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.0.0",
-
     "date-fns": "^3.6.0",
     "embla-carousel-react": "^8.3.0",
     "framer-motion": "^12.6.2",

--- a/package.json
+++ b/package.json
@@ -12,10 +12,8 @@
   },
   "scripts": {
     "dev": "vite",
-    "build": "npm run build:client && npm run build:server",
-    "build:client": "vite build",
-    "build:server": "vite build --config vite.config.server.ts",
-    "start": "node dist/server/node-build.mjs",
+    "build": "vite build",
+    "preview": "vite preview",
     "test": "vitest --run",
     "format.fix": "prettier --write .",
     "typecheck": "tsc"

--- a/vercel.json
+++ b/vercel.json
@@ -1,16 +1,7 @@
 {
-  "buildCommand": "npm run build:client",
+  "buildCommand": "npm run build",
   "outputDirectory": "dist/spa",
-  "functions": {
-    "api/index.ts": {
-      "runtime": "@vercel/node@18.x"
-    }
-  },
   "routes": [
-    {
-      "src": "/api/(.*)",
-      "dest": "/api/index.ts"
-    },
     {
       "src": "/(.*)",
       "dest": "/index.html"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,6 @@
-import { defineConfig, Plugin } from "vite";
+import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import path from "path";
-import { createServer } from "./server";
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
@@ -10,13 +9,13 @@ export default defineConfig(({ mode }) => ({
     port: 8080,
     fs: {
       allow: ["./client", "./shared"],
-      deny: [".env", ".env.*", "*.{crt,pem}", "**/.git/**", "server/**"],
+      deny: [".env", ".env.*", "*.{crt,pem}", "**/.git/**"],
     },
   },
   build: {
     outDir: "dist/spa",
   },
-  plugins: [react(), expressPlugin()],
+  plugins: [react()],
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./client"),
@@ -24,16 +23,3 @@ export default defineConfig(({ mode }) => ({
     },
   },
 }));
-
-function expressPlugin(): Plugin {
-  return {
-    name: "express-plugin",
-    apply: "serve", // Only apply during development (serve mode)
-    configureServer(server) {
-      const app = createServer();
-
-      // Add Express app as middleware to Vite dev server
-      server.middlewares.use(app);
-    },
-  };
-}


### PR DESCRIPTION
## Purpose

Based on the conversation history, the user wanted to remove the Express backend server connectivity and keep only the frontend part. The goal was to prepare a frontend-only React application for deployment on Vercel, eliminating any backend dependencies.

## Code changes

- **Removed Express dependencies**: Eliminated `express`, `cors`, `dotenv` and their type definitions from package.json
- **Simplified build scripts**: Removed separate client/server build commands, now using single `vite build`
- **Updated Vercel configuration**: Removed API functions and routes, simplified to serve only static frontend files
- **Cleaned up Vite config**: Removed Express plugin and server creation logic, simplified to basic React setup
- **Removed server middleware**: Eliminated Express integration from Vite development server

The application is now a pure frontend React app ready for static deployment on Vercel.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 5`

🔗 [Edit in Builder.io](https://builder.io/app/projects/2aaff5b291f343d19975471edcbffdcf/orbit-nest)

👀 [Preview Link](https://2aaff5b291f343d19975471edcbffdcf-orbit-nest.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>2aaff5b291f343d19975471edcbffdcf</projectId>-->
<!--<branchName>orbit-nest</branchName>-->